### PR TITLE
Patterns can be named

### DIFF
--- a/tr808-pi.rb
+++ b/tr808-pi.rb
@@ -1,8 +1,7 @@
-
 # global map for sample to:
 # - path (location of sample dir)
 # - version (which file to pick for sample when there are multiple)
-# - hits (whether to play the instrument or not)
+# - hits (Hash<String, List> where keys represent names of patterns, and List is hits)
 # then some custom params for sample arguments like BD_amp for amp
 # which will initially set by `setup_samples()`
 $samples_map = {}
@@ -41,13 +40,15 @@ def setup_samples()
     $samples_map[sym_key] = {
       :path => path,
       :version => 1, # which file to pick for samples
-      :hits => []
+      # hits is a Hash that looks like this:
+      # {"A": [0..n], "B": [0..n], ... }
+      :hits => {}
     }
     set amp_param, 1.5
   end
 end
 
-def inst_to_binary(splitlines)
+def inst_to_binary(splitlines, pattern_name=0)
   # first, we map each instrument to its hit pattern
   inst_to_hits = splitlines.map{
     |line|
@@ -61,9 +62,10 @@ def inst_to_binary(splitlines)
     return splits.map(&:to_i)
   end
 
-  # then, create a dictionary of inst => [0s, 1s]
+  # make a Hash out of the list pair ["inst", [0..n]]
+  # such that values represent named pattern
   return inst_to_hits.map{
-    |k, v| [k.to_sym, make_hits(v)]
+    |k, v| [k.to_sym, {pattern_name => make_hits(v)}]
   }.to_h
 end
 
@@ -72,16 +74,18 @@ def parse_beat(src)
   Return a dictionary representing a beat pattern for the TR-808.
 
   Args:
-      src (Integer or Array): The string(s) representing the beat pattern.
+      src (String, Array<String>, Hash<String, String>): 
+      The string(s) representing the beat pattern.
 
   Returns:
       The dictionary.
   """
   setup_samples()
 
+  # helper function to update the $samples_map
   def set_hits(hits)
-    hits.each do |k, v|
-      $samples_map[k][:hits].push(v)
+    hits.each do |inst, hits_dict|
+      $samples_map[inst][:hits] = hits_dict
     end
   end
 
@@ -92,11 +96,46 @@ def parse_beat(src)
     set_hits(hits)
   elsif src.class == Array
     # for multiple patterns, create hits for each pattern
-    src.each do |pattern|
+    final_hits = {}
+    src.each_with_index do |pattern, index|
       pattern = pattern.gsub(/^\s+/, '').strip
-      hits = inst_to_binary(pattern.split("\n"))
-      set_hits(hits)
+      # by default, pattern for each pattern is the index
+      hits = inst_to_binary(pattern.split("\n"), pattern_name = index)
+
+      # initialize the final hits hash if it's the first entry
+      if final_hits.length == 0
+        final_hits = hits
+      else
+        # otherwise, update the hits hash of each instrument
+        # in final_hits so we add more patterns
+        hits.each do |name, pattern|
+          # pp final_hits[name]
+          final_hits[name] = final_hits[name].merge(pattern)
+        end
+      end
     end
+    
+    set_hits(final_hits)
+  elsif src.class == Hash
+    # for multiple named patterns, create hits for each pattern with 
+    # name specified by user
+    final_hits = {}
+    src.each do |name, pattern|
+      pattern = pattern.gsub(/^\s+/, '').strip
+      hits = inst_to_binary(pattern.split("\n"), pattern_name = name)
+
+      # initialize the final hits hash if it's the first entry
+      if final_hits.length == 0
+        final_hits = hits
+      else
+        # otherwise, update the hits hash of each instrument
+        # in final_hits so we add more patterns
+        hits.each do |name, pattern|
+          final_hits[name] = final_hits[name].merge(pattern)
+        end
+      end
+    end
+    set_hits(final_hits)
   end
 end
 
@@ -125,14 +164,23 @@ end
 
 def tr808(src, bpm: 90, pattern: [0])
   """
-  Play a live loop of the TR-808 given a beat pattern and bpm.
+  Play a live loop of the TR-808 given a beat pattern(s) and bpm.
 
   Args:
-      src (String): The string representing the TR-808 beat pattern.
+      src (String, Array<String>, Hash<String, String>): 
+        The string(s) representing the TR-808 beat pattern(s).
+        
+        For 1 pattern, provide a String for the pattern. For multiple
+        patterns that are not named, provide an Array of Strings.
+        
+        If you want to name each pattern, provide a Hash with the key
+        representing the name of pattern and the value as the String pattern.
       bpm (Integer): The bpm, 90 by default.
-      pattern (Array): An array of which pattern to play if there are 
-        multiple patterns, [0] by default for one single pattern
-
+      pattern (Array<Integer>, Array<String>): 
+        An array of which pattern to play if there are 
+        multiple patterns, [0] by default for one single pattern. 
+        
+        For specifying names of the pattern provide an Array of String(s).
   Returns:
       nil
   """
@@ -148,7 +196,7 @@ def tr808(src, bpm: 90, pattern: [0])
       # for each instrument, play the sample if it's a hit
       $samples_map.each do |inst, values|
         hits = values[:hits]
-        if hits.length && cur_pattern < hits.length && hits[cur_pattern][i] == 1
+        if hits.length && hits.has_key?(cur_pattern) && hits[cur_pattern][i] == 1
           sample_tr808(inst)
         end
       end


### PR DESCRIPTION
fixes https://github.com/nischalshrestha/tr808-pi/issues/8

Patterns can now be named if passing a Hash like:

```rb
tr808({
'A' =>
"
OH ----|----|----|----
CH x-x-|x-x-|x-x-|x-x-
SD ----|x---|----|x---
BD x---|----|--x-|----
",
'B' => 
"
OH ----|--x-|----|----
CH x-x-|x-x-|x-x-|x-x-
SD ----|x--x|-x--|x---
BD x---|----|--x-|----
",
'C' =>
"
OH ----|--x-|--x-|----
CH xxxx|xxxx|xxxx|xxxx
SD ----|x--x|-x--|x---
BD x---|----|--x-|----
"
}, bpm: 118, pattern: ["A", "B", "C"])
```

The `hits` data structure changed from a simple `Array<Array>` to `Hash<String | Integer, List<Integer>>`, where default pattern names depend on the type of the source string for patterns for `tr808()`:

- for single string, patterns are named `0` by default since it's one pattern
- for an Array, names correspond to the index numbers (e.g. `0`, `1`, etc)
- for named patterns, or a `Hash`, the user supplied `String` key(s) is the pattern name (e.g. `"A"`, `"B"`, etc.),

Manually tested this is working. Eventually we may want to simplify or clean up some of the logic in `parse_beat()` where there's slight duplication of logic btw Array and Hash input types.
 
TODO:

- [ ] tests